### PR TITLE
Update copyright year

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,8 +54,8 @@ the problem once and for all.
     </pre></section>
 
     <section class="copyright"><pre>
-&copy; 2012-2014 Sam Stephenson, Basecamp
-</pre></section>
+&copy; 2012-2016 Sam Stephenson, Basecamp
+    </pre></section>
 
     <script type="text/javascript">
       var clicky_site_ids = clicky_site_ids || [];


### PR DESCRIPTION
The xip.io website says "Copyright 2011–2014" right now, so this PR updates it to 2016.
