### PR TITLE
Support for NS Subdomain Prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+etc/xip-pdns.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get upgrade -y --force-yes && \
+    apt-get install -y pdns-server pdns-backend-pipe
+
+# remove all other pdns backends
+RUN rm -f /etc/powerdns/pdns.d/*
+
+# install our source and powerdns backend configurations
+ADD bin/xip-pdns /usr/local/bin/xip-pdns
+ADD etc/xip-pdns.backend.conf.example /etc/powerdns/pdns.d/xip.conf
+
+# expose dns ports
+EXPOSE 53/udp 53/tcp
+
+CMD ["pdns_server", "--master", "--daemon=no", "--local-address=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ XIP_ROOT_ADDRESSES=( "1.2.3.1" )
 # `A` queries for these subdomains map to the corresponding addresses here.
 XIP_NS_ADDRESSES=( "1.2.3.4" "1.2.3.5" )
 
+# Subdomain prefix for NS Records (i.e. ns-1.xip.test)
+XIP_NS_SUBDOMAIN_PREFIX="ns-"
+
 # How long responses should be cached, in seconds.
 XIP_TTL=300
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ XIP_TTL=300
 
 Then copy `etc/xip-pdns.backend.conf.example` to 
 `/etc/powerdns/pdns.d/xip.conf` (or the appropriate PowerDNS backend adapter 
-configuration location for your system(, and modify to meet your needs.
+configuration location for your system), and modify to meet your needs.
 
 Example: 
 
@@ -45,6 +45,9 @@ Example:
 launch=pipe
 pipe-command=/usr/local/bin/xip-pdns /etc/xip-pdns.conf
 ```
+
+Finally, copy `bin/xip-pdns` to `/usr/local/bin/xip-pdns` (or wherever you 
+prefer).
 
 Restart PowerDNS, and test.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,92 @@
-#### xip-pdns
+# XIP PowerDNS Backend Adapter
 
-This is the source of the [PowerDNS](http://powerdns.com/) pipe backend adapter powering [xip.io](http://xip.io/).
+This is the source of the [PowerDNS](http://powerdns.com/) pipe backend 
+adapter powering [xip.io](http://xip.io/).
 
-Install this on your system, adjust [etc/xip-pdns.conf](etc/xip-pdns.conf.example) to your liking, and configure PowerDNS as follows:
+## Deploying Manually
 
-    launch=pipe
-    pipe-command=/path/to/xip-pdns/bin/xip-pdns /path/to/xip-pdns/etc/xip-pdns.conf
+Copy `etc/xip-pdns.conf.example` to `/etc/xip-pdns.conf`, and modify to meet 
+your needs.  
 
+Example: 
+
+**/etc/xip-pdns.conf**
+
+```
+# Increment this timestamp when the contents of the file change.
+XIP_TIMESTAMP="2014102800"
+
+# The top-level domain for which the name server is authoritative.
+XIP_DOMAIN="xip.test"
+
+# The public IP addresses (e.g. for the web site) of the top-level domain.
+# `A` queries for the top-level domain will return this list of addresses.
+XIP_ROOT_ADDRESSES=( "1.2.3.1" )
+
+# The public IP addresses on which this xip-pdns server will run.
+# `NS` queries for the top-level domain will return this list of addresses.
+# Each entry maps to a 1-based subdomain of the format `ns-1`, `ns-2`, etc.
+# `A` queries for these subdomains map to the corresponding addresses here.
+XIP_NS_ADDRESSES=( "1.2.3.4" "1.2.3.5" )
+
+# How long responses should be cached, in seconds.
+XIP_TTL=300
+```
+
+Then copy `etc/xip-pdns.backend.conf.example` to 
+`/etc/powerdns/pdns.d/xip.conf` (or the appropriate PowerDNS backend adapter 
+configuration location for your system(, and modify to meet your needs.
+
+Example: 
+
+**/etc/powerdns/pdns.d/xip.conf**
+
+```
+launch=pipe
+pipe-command=/usr/local/bin/xip-pdns /etc/xip-pdns.conf
+```
+
+Restart PowerDNS, and test.
+
+```
+$ dig test.10.0.0.1.xip.test @localhost
+;; ANSWER SECTION:
+test.10.0.0.1.xip.test. 300     IN      A       10.0.0.1
+```
+
+*Note: Replace `localhost` with the address of the host running PowerDNS.*
+
+## Deploying with Docker
+
+XIP PDNS can easily be deployed with the included Dockerfile as follows.  
+First copy `etc/xip-pdns.conf.example` to `/path/to/xip-pdns.conf` (wherever 
+you want it), and modify for your needs.   Build, and run with Docker:
+
+```
+$ cp -a etc/xip-pdns.conf.example etc/xip-pdns.conf
+
+$ docker build -t 'xip-pdns' .
+
+$ docker run -it \
+    -p 0.0.0.0:53:53/tcp \
+    -p 0.0.0.0:53:53/udp \
+    -v ./etc/xip-pdns.conf:/etc/xip-pdns.conf \
+    xip-pdns
+```
+
+Alternatively, the above can be run with Docker Compose using the included
+`docker-compose.yml`:
+
+```
+$ docker-compose up
+```
+
+And test:
+
+```
+$ dig test.10.0.0.1.xip.test @localhost
+;; ANSWER SECTION:
+test.10.0.0.1.xip.test. 300     IN      A       10.0.0.1
+```
+
+*Note: Replace `localhost` with the host running the Docker container.*

--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -15,6 +15,7 @@ fi
 [ -z "$XIP_DOMAIN" ] && XIP_DOMAIN="xip.test"
 [ -z "$XIP_ROOT_ADDRESSES" ] && XIP_ROOT_ADDRESSES=( "127.0.0.1" )
 [ -z "$XIP_NS_ADDRESSES" ] && XIP_NS_ADDRESSES=( "127.0.0.1" )
+[ -z "$XIP_NS_SUBDOMAIN_PREFIX" ] && XIP_NS_SUBDOMAIN_PREFIX='ns-'
 [ -z "$XIP_TIMESTAMP" ] && XIP_TIMESTAMP="0"
 [ -z "$XIP_TTL" ] && XIP_TTL=300
 
@@ -68,7 +69,7 @@ log() {
 # xip.io domain helpers
 #
 XIP_DOMAIN_PATTERN="(^|\.)${XIP_DOMAIN//./\.}\$"
-NS_SUBDOMAIN_PATTERN="^ns-([0-9]+)\$"
+NS_SUBDOMAIN_PATTERN="^${XIP_NS_SUBDOMAIN_PREFIX}([0-9]+)\$"
 IP_SUBDOMAIN_PATTERN="(^|\.)(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))\$"
 BASE36_SUBDOMAIN_PATTERN="(^|\.)([a-z0-9]{1,7})\$"
 
@@ -118,14 +119,14 @@ resolve_base36_subdomain() {
 }
 
 answer_soa_query() {
-  send_answer "SOA" "admin.$XIP_DOMAIN ns-1.$XIP_DOMAIN $XIP_TIMESTAMP $XIP_TTL $XIP_TTL $XIP_TTL $XIP_TTL"
+  send_answer "SOA" "admin.$XIP_DOMAIN ${XIP_NS_SUBDOMAIN_PREFIX}1.$XIP_DOMAIN $XIP_TIMESTAMP $XIP_TTL $XIP_TTL $XIP_TTL $XIP_TTL"
 }
 
 answer_ns_query() {
   local i=1
   local ns_address
   for ns_address in "${XIP_NS_ADDRESSES[@]}"; do
-    send_answer "NS" "ns-$i.$XIP_DOMAIN"
+    send_answer "NS" "${XIP_NS_SUBDOMAIN_PREFIX}$i.$XIP_DOMAIN"
     let i+=1
   done
 }

--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -3,18 +3,20 @@ set -e
 shopt -s nocasematch
 
 #
-# Configuration
+# Source Configuration File Defaults
 #
-XIP_DOMAIN="xip.test"
-XIP_ROOT_ADDRESSES=( "127.0.0.1" )
-XIP_NS_ADDRESSES=( "127.0.0.1" )
-XIP_TIMESTAMP="0"
-XIP_TTL=300
-
 if [ -a "$1" ]; then
   source "$1"
 fi
 
+#
+# Configuration Default Settings (if not yet provided)
+#
+[ -z "$XIP_DOMAIN" ] && XIP_DOMAIN="xip.test"
+[ -z "$XIP_ROOT_ADDRESSES" ] && XIP_ROOT_ADDRESSES=( "127.0.0.1" )
+[ -z "$XIP_NS_ADDRESSES" ] && XIP_NS_ADDRESSES=( "127.0.0.1" )
+[ -z "$XIP_TIMESTAMP" ] && XIP_TIMESTAMP="0"
+[ -z "$XIP_TTL" ] && XIP_TTL=300
 
 #
 # Protocol helpers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: '2'
+services:
+    xip:
+        build: .
+        volumes: 
+            - ./etc/xip-pdns.conf:/etc/xip-pdns.conf
+        ports:
+            - "53:53/tcp"
+            - "53:53/udp"
+

--- a/etc/xip-pdns.backend.conf.example
+++ b/etc/xip-pdns.backend.conf.example
@@ -1,0 +1,2 @@
+launch=pipe
+pipe-command=/usr/local/bin/xip-pdns /etc/xip-pdns.conf

--- a/etc/xip-pdns.conf.example
+++ b/etc/xip-pdns.conf.example
@@ -14,5 +14,8 @@ XIP_ROOT_ADDRESSES=( "1.2.3.1" )
 # `A` queries for these subdomains map to the corresponding addresses here.
 XIP_NS_ADDRESSES=( "1.2.3.4" "1.2.3.5" )
 
+# Subdomain prefix for NS Records (i.e. ns-1.xip.test)
+XIP_NS_SUBDOMAIN_PREFIX="ns-"
+
 # How long responses should be cached, in seconds.
 XIP_TTL=300


### PR DESCRIPTION
Default is `ns-1`, `ns-2`, etc... this allows the user to override the prefix so that if `XIP_NS_SUBDOMAIN_PREFIX="alternative-ns"` the resulting NS records would be `alternative-ns1`, `alternative-ns2`, etc (intentionally using an odd name for clarity).  In my use cause, using `ns01`, `ns02`, etc fits existing naming schema and needed to be able to override the default.
