### PR TITLE
support AAAA records

### DIFF
--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -67,6 +67,7 @@ log() {
 #
 XIP_DOMAIN_PATTERN="(^|\.)${XIP_DOMAIN//./\.}\$"
 NS_SUBDOMAIN_PATTERN="^ns-([0-9]+)\$"
+V6_SUBDOMAIN_PATTERN="(^|\.)v6-([a-fA-F0-9-]+)\$"
 IP_SUBDOMAIN_PATTERN="(^|\.)(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))\$"
 BASE36_SUBDOMAIN_PATTERN="(^|\.)([a-z0-9]{1,7})\$"
 
@@ -99,6 +100,10 @@ subdomain_is_base36() {
   [[ "$SUBDOMAIN" =~ $BASE36_SUBDOMAIN_PATTERN ]]
 }
 
+subdomain_is_v6() {
+  [[ "$SUBDOMAIN" =~ $V6_SUBDOMAIN_PATTERN ]]
+}
+
 resolve_ns_subdomain() {
   local index="${SUBDOMAIN:3}"
   echo "${XIP_NS_ADDRESSES[$index-1]}"
@@ -113,6 +118,11 @@ resolve_base36_subdomain() {
   [[ "$SUBDOMAIN" =~ $BASE36_SUBDOMAIN_PATTERN ]] || true
   local ip=$(( 36#${BASH_REMATCH[2]} ))
   printf "%d.%d.%d.%d" $(( ip&0xFF )) $(( (ip>>8)&0xFF )) $(( (ip>>16)&0xFF )) $(( (ip>>24)&0xFF ))
+}
+
+resolve_v6_subdomain() {
+  [[ "$SUBDOMAIN" =~ $V6_SUBDOMAIN_PATTERN ]] || true
+  echo "${BASH_REMATCH[2]}" | sed 's/-/:/g'
 }
 
 answer_soa_query() {
@@ -138,7 +148,9 @@ answer_root_a_query() {
 answer_subdomain_a_query_for() {
   local type="$1"
   local address="$(resolve_${type}_subdomain)"
-  if [ -n "$address" ]; then
+  if [[ "$address" =~ ":" ]]; then
+    send_answer "AAAA" "$address"
+  elif [ -n "$address" ]; then
     send_answer "A" "$address"
   fi
 }
@@ -179,6 +191,15 @@ while read_query; do
 
       elif subdomain_is_base36; then
         answer_subdomain_a_query_for base36
+
+      elif subdomain_is_v6; then
+        answer_subdomain_a_query_for v6
+      fi
+    elif qtype_is "AAAA"; then
+      extract_subdomain_from_qname
+
+      if subdomain_is_v6; then
+        answer_subdomain_a_query_for v6
       fi
     fi
   fi


### PR DESCRIPTION
This PR adds support for AAAA records that take the form *.v6-[ip]-[v6]-[addr].xip.test.

For example:

```
$ dig v6-fda9-6b94-9d5-4c-a3-df-57-b4.xip.test AAAA +short
fda9:6b94:9d5:4c:a3:df:57:b4
$ dig www.v6-fda9-6b94-9d5-4c-a3-df-57-b4.xip.test AAAA +short
fda9:6b94:9d5:4c:a3:df:57:b4
$ dig v6-fda9-6b94-9d5--2.xip.test AAAA +short
fda9:6b94:9d5::2
```