### PR TITLE
is base36 resolve returning an inverted IPv4 address?

### DIFF
--- a/bin/xip-pdns
+++ b/bin/xip-pdns
@@ -112,7 +112,7 @@ resolve_ip_subdomain() {
 resolve_base36_subdomain() {
   [[ "$SUBDOMAIN" =~ $BASE36_SUBDOMAIN_PATTERN ]] || true
   local ip=$(( 36#${BASH_REMATCH[2]} ))
-  printf "%d.%d.%d.%d" $(( ip&0xFF )) $(( (ip>>8)&0xFF )) $(( (ip>>16)&0xFF )) $(( (ip>>24)&0xFF ))
+  printf "%d.%d.%d.%d" $(( (ip>>24)&0xFF )) $(( (ip>>16)&0xFF )) $(( (ip>>8)&0xFF )) $(( ip&0xFF ))
 }
 
 answer_soa_query() {


### PR DESCRIPTION
Hi,

I've tested resolving the base36 name for the first time today, and I got the impression that it's returning an **inverted** IPv4 as the response.

I've tried with IP **104.131.190.237**. So first I got the decimal value from it:
```
$ echo $(( (104 * (256**3)) + (131 * (256**2)) + (190 * 256) + 237 ))
1753464557
```

Converting to base36 that gives: szytwt

But when resolving it's returning the previous IP inverted:
```
$ ping szytwt.xip.io
PING szytwt.xip.io (237.190.131.104) 56(84) bytes of data.
```

Is that correct and I'm missing something very obvious? Or is it returning the IP inverted?

Thanks in advance.